### PR TITLE
Remove employee fix

### DIFF
--- a/src/components/control-panel-pages/employees/employees-list/employees-list.jsx
+++ b/src/components/control-panel-pages/employees/employees-list/employees-list.jsx
@@ -1,11 +1,9 @@
 import React from "react";
 import "./employees-list.css";
 import endpointUrl from "../../../../config";
-import { useHistory } from "react-router-dom";
 import CircularProgress from "../../../general/CircularProgress";
 
-export default () => {
-  const history = useHistory();
+export default () => {  
   const [list, setList] = React.useState([]);
 
   React.useEffect(() => {
@@ -23,8 +21,8 @@ export default () => {
       }
     })
     .then(res => {
-      if (res.status === 200) {
-        history.push("/employees")
+      if (res.status === 200) {        
+        window.location.reload();
       }
     });
   };  


### PR DESCRIPTION
This fix means that now when an admin clicks `Remove` on employee-list, if the server responds with 200, we will refresh page so we can see an updated list.